### PR TITLE
Make Argo a JPMS module

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module mx.kenzie.argo {
+    exports mx.kenzie.argo;
+    exports mx.kenzie.argo.meta;
+    requires jdk.unsupported;
+}


### PR DESCRIPTION
This PR adds a `module-info.java` file to Argo's source root, converting it to a JPMS module. This has several benefits:
- More control over which Argo packages should be visible to API users
- Explicit, compile-checked separation between internal functionality and the library API
- **Functionality in JPMS dependencies via jdk.unsupported `requires` declaration**